### PR TITLE
Make the default class configurable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
+        "illuminate/config": "~5.0",
         "illuminate/http": "~5.0",
         "illuminate/routing": "~5.0",
         "illuminate/support": "~5.0"

--- a/src/Active.php
+++ b/src/Active.php
@@ -4,6 +4,7 @@ namespace Watson\Active;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 
 class Active
@@ -65,11 +66,15 @@ class Active
      * @param  string  $class
      * @return string|null
      */
-    public function active($routes, $class = 'active')
+    public function active($routes, $class = null)
     {
         $routes = (array) $routes;
 
-        return $this->isActive($routes) ? $class : null;
+        if ($this->isActive($routes)) {
+            return $class ?: Config::get('active.class');
+        }
+
+        return null;
     }
 
     /**
@@ -92,11 +97,15 @@ class Active
      * @param  string  $class
      * @return string|null
      */
-    public function path($routes, $class = 'active')
+    public function path($routes, $class = null)
     {
         $routes = (array) $routes;
 
-        return $this->isPath($routes) ? $class : null;
+        if ($this->isPath($routes)) {
+            return $class ?: Config::get('active.class');
+        }
+
+        return null;
     }
 
     /**
@@ -119,11 +128,15 @@ class Active
      * @param  string  $class
      * @return string|null
      */
-    public function route($routes, $class = 'active')
+    public function route($routes, $class = null)
     {
         $routes = (array) $routes;
 
-        return $this->isRoute($routes) ? $class : null;
+        if ($this->isRoute($routes)) {
+            return $class ?: Config::get('active.class');
+        }
+
+        return null;
     }
 
     /**

--- a/src/Active.php
+++ b/src/Active.php
@@ -1,11 +1,11 @@
-<?php 
+<?php
 
 namespace Watson\Active;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Str;
+use Illuminate\Config\Repository;
 
 class Active
 {
@@ -23,17 +23,26 @@ class Active
      */
     protected $router;
 
-    /** 
+    /**
+     * Illuminate Config instance.
+     *
+     * @var \Illuminate\Config\Repository
+     */
+    protected $config;
+
+    /**
      * Construct the class.
      *
-     * @param  \Illuminate\Http\Request    $request
-     * @param  \Illuminate\Routing\Router  $router
+     * @param  \Illuminate\Http\Request       $request
+     * @param  \Illuminate\Routing\Router     $router
+     * @param  \Illuminate\Config\Repository  $config
      * @return void
      */
-    public function __construct(Request $request, Router $router)
+    public function __construct(Request $request, Router $router, Repository $config)
     {
         $this->request = $request;
         $this->router = $router;
+        $this->config = $config;
     }
 
     /**
@@ -71,10 +80,8 @@ class Active
         $routes = (array) $routes;
 
         if ($this->isActive($routes)) {
-            return $class ?: Config::get('active.class');
+            return $this->getActiveClass($class);
         }
-
-        return null;
     }
 
     /**
@@ -102,10 +109,8 @@ class Active
         $routes = (array) $routes;
 
         if ($this->isPath($routes)) {
-            return $class ?: Config::get('active.class');
+            return $this->getActiveClass($class);
         }
-
-        return null;
     }
 
     /**
@@ -133,10 +138,20 @@ class Active
         $routes = (array) $routes;
 
         if ($this->isRoute($routes)) {
-            return $class ?: Config::get('active.class');
+            return $this->getActiveClass($class);
         }
+    }
 
-        return null;
+    /**
+     * Return the active class if it is provided, otherwise fall back
+     * to the class set in the configuration.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function getActiveClass($class = null)
+    {
+        return $class ?: $this->config->get('active.class');
     }
 
     /**

--- a/src/ActiveServiceProvider.php
+++ b/src/ActiveServiceProvider.php
@@ -21,6 +21,22 @@ class ActiveServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind('active', Active::class);
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/config.php', 'active'
+        );
+    }
+
+    /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__ . '/config/config.php' => config_path('active.php'),
+        ], 'config');
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,15 +1,17 @@
 <?php
 
 return [
+
     /*
     |--------------------------------------------------------------------------
     | Active class
     |--------------------------------------------------------------------------
     |
     | Here you may set the class string to be returned when the provided routes
-    | or paths were identified as applicable for the current page.
+    | or paths were identified as applicable for the current route.
     |
     */
 
     'class' => 'active',
+
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Active class
+    |--------------------------------------------------------------------------
+    |
+    | Here you may set the class string to be returned when the provided routes
+    | or paths were identified as applicable for the current page.
+    |
+    */
+
+    'class' => 'active',
+];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,7 +39,7 @@ if ( ! function_exists('active')) {
      * @param  string  $class
      * @return string|null
      */
-    function active($routes = null, $class = 'active')
+    function active($routes = null, $class = null)
     {
         if (is_null($routes)) {
             return App::make('active');

--- a/tests/ActiveTest.php
+++ b/tests/ActiveTest.php
@@ -3,6 +3,7 @@
 use Watson\Active\Active;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Config\Repository;
 
 class ActiveTest extends PHPUnit_Framework_TestCase
 {
@@ -17,16 +18,16 @@ class ActiveTest extends PHPUnit_Framework_TestCase
         parent::setUp();
 
         $this->request = Mockery::mock(Request::class);
-
         $this->router = Mockery::mock(Router::class);
+        $this->config = Mockery::mock(Repository::class);
 
-        $this->active = new Active($this->request, $this->router);
+        $this->active = new Active($this->request, $this->router, $this->config);
     }
 
     public function tearDown()
     {
         parent::tearDown();
-        
+
         Mockery::close();
     }
 
@@ -100,7 +101,21 @@ class ActiveTest extends PHPUnit_Framework_TestCase
 
         $this->request->shouldReceive('is')->with()->andReturn(false);
 
+        $this->config->shouldReceive('get')->with('active.class')->once()->andReturn('active');
+
         $result = $this->active->active('foo');
+
+        $this->assertEquals('active', $result, "Wrong string returned when current path provided.");
+    }
+
+    /** @test */
+    public function active_returns_provided_class_when_on_path()
+    {
+        $this->request->shouldReceive('is')->with('foo')->andReturn(true);
+
+        $this->request->shouldReceive('is')->with()->andReturn(false);
+
+        $result = $this->active->active('foo', 'active');
 
         $this->assertEquals('active', $result, "Wrong string returned when current path provided.");
     }
@@ -126,7 +141,7 @@ class ActiveTest extends PHPUnit_Framework_TestCase
 
         $result = $this->active->active('foo');
 
-        $this->assertNull($result, "Returned string when the current route or path is not provided.");    
+        $this->assertNull($result, "Returned string when the current route or path is not provided.");
     }
 
 
@@ -134,6 +149,8 @@ class ActiveTest extends PHPUnit_Framework_TestCase
     public function path_returns_active_when_on_path()
     {
         $this->request->shouldReceive('is')->andReturn(true);
+
+        $this->config->shouldReceive('get')->with('active.class')->once()->andReturn('active');
 
         $result = $this->active->path('foo');
 
@@ -164,6 +181,8 @@ class ActiveTest extends PHPUnit_Framework_TestCase
     public function route_returns_active_when_on_route()
     {
         $this->router->shouldReceive('is')->andReturn(true);
+
+        $this->config->shouldReceive('get')->with('active.class')->once()->andReturn('active');
 
         $result = $this->active->route('foo');
 


### PR DESCRIPTION
The hardcoded `active` class is preventing me from using the package, as I'd currently have to provide my app's active class in each call. It would be great if this PR gets merged. I didn't write any tests so you can implement them how you like.