### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - php composer.phar install
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.2",
         "illuminate/config": "~5.5",
         "illuminate/http": "~5.5",
         "illuminate/routing": "~5.5",
         "illuminate/support": "~5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0",
+        "phpunit/phpunit": "~8.0",
         "mockery/mockery": "~1.0"
     },
     "autoload": {

--- a/tests/ActiveTest.php
+++ b/tests/ActiveTest.php
@@ -14,7 +14,7 @@ class ActiveTest extends TestCase
 
     protected $router;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -25,7 +25,7 @@ class ActiveTest extends TestCase
         $this->active = new Active($this->request, $this->router, $this->config);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -10,7 +10,7 @@ class RouteTest extends TestCase
 
     protected $router;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -19,7 +19,7 @@ class RouteTest extends TestCase
         $this->route = new Route($this->router);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/helpersTest.php
+++ b/tests/helpersTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\App;
 
 class HelpersTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `PHPUnit\Framework\TestCase::setpUp` and `tearDown` should be `protected`, not `public`.