### PR TITLE
PHP min. required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^7.1",
         "illuminate/config": "~5.5",
         "illuminate/http": "~5.5",
         "illuminate/routing": "~5.5",


### PR DESCRIPTION
Minimum version IMHO should be as Laravel ones. For PHP 7.1.29 it fails.