### PR TITLE
 Added support laravel v6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/config": "~5.5",
-        "illuminate/http": "~5.5",
-        "illuminate/routing": "~5.5",
-        "illuminate/support": "~5.5"
+        "illuminate/config": "^6.0",
+        "illuminate/http": "^6.0",
+        "illuminate/routing": "^6.0",
+        "illuminate/support": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",

--- a/src/Route.php
+++ b/src/Route.php
@@ -51,7 +51,7 @@ class Route
             }
 
             // Separate out nested controller resources.
-            $controller = str_replace('_', $separator, snake_case($controller));
+            $controller = str_replace('_', $separator, Str::snake($controller));
 
             // Either separate out the namespaces or remove them.
             $controller = $includeNamespace ? str_replace('\\', null, $controller) : substr(strrchr($controller, '\\'), 1);


### PR DESCRIPTION
Hello!

The release of Laravel 6.0 will be tomorrow.
It would be great to prepare now.

Should the package do a new major version? 
If not, then we could add:
```
"illuminate/support": "^5.5|^6.0|6.0.x-dev",
...
```