### PR TITLE
Added PHP 7.4 for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
Hey. A new version was released last year. I think we should check it for compatibility.