### PR TITLE
Added support laravel 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/config": "^6.0",
-        "illuminate/http": "^6.0",
-        "illuminate/routing": "^6.0",
-        "illuminate/support": "^6.0"
+        "illuminate/config": "^7.0",
+        "illuminate/http": "^7.0",
+        "illuminate/routing": "^7.0",
+        "illuminate/support": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",


### PR DESCRIPTION
Hey. The release of laravel 7.0 should take place on March 3rd, we can prepare it now. 
This does not require any code changes.