### PR TITLE
Bump PHP version constraint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/config": "^8.0",
         "illuminate/http": "^8.0",
         "illuminate/routing": "^8.0",


### PR DESCRIPTION
PHP8 is released. Because `"php": "^7.3",` I cant use the package on PHP8. thats why i replaced it to `"php": "^7.3|^8.0",`